### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,11 @@
 name: Auto-fix formatting
-on: push
+on:
+  push:
+    branches-ignore:
+      - trunk
 permissions:
   contents: write
+
 jobs:
   fix:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Run tests
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/akselinurmio/akselinurmio.fi/security/code-scanning/1](https://github.com/akselinurmio/akselinurmio.fi/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it appears that only read access to repository contents is necessary. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
